### PR TITLE
Fix userRepo test

### DIFF
--- a/test/UserRepository-test.js
+++ b/test/UserRepository-test.js
@@ -1,37 +1,41 @@
 import { expect } from 'chai';
 import UserRepository from '../src/UserRepository'
-//import userData from './src/data/users';
 
 describe('User Repository', () => {
+  let repo;
+
+
+beforeEach(() => {
+  repo = new UserRepository([{
+    id: 1,
+    name: "Luisa Hane",
+    address: "15195 Nakia Tunnel, Erdmanport VA 19901-1697",
+    email: "Diana.Hayes1@hotmail.com",
+    strideLength: 4.3,
+    dailyStepGoal: 10000,
+    friends: [16, 4, 8]
+  }])
+})
   it('should be a function', function () {
     expect(UserRepository).to.be.a('function');
 
   });
-  it('should have user data', function () {
-    let user1 = new UserRepository(userData)
-    expect(user1.data).to.be.a('array')
-
+  it('should be an instance of UserRepository', function () {
+    expect(repo).to.be.an.instanceof(UserRepository)
   })
-  it('should be able to fetch one persons data', function () {
-    let user1 = new UserRepository(userData)
-    user1.findUsersData(1)
-    expect(user1.currentUser).to.deep.equal([{
-      "id": 1,
-      "name": "Luisa Hane",
-      "address": "15195 Nakia Tunnel, Erdmanport VA 19901-1697",
-      "email": "Diana.Hayes1@hotmail.com",
-      "strideLength": 4.3,
-      "dailyStepGoal": 10000,
-      "friends": [
-        16,
-        4,
-        8
-      ]
+  it('should have user data', function () {
+    expect(repo.data).to.deep.equal([{
+      id: 1,
+      name: "Luisa Hane",
+      address: "15195 Nakia Tunnel, Erdmanport VA 19901-1697",
+      email: "Diana.Hayes1@hotmail.com",
+      strideLength: 4.3,
+      dailyStepGoal: 10000,
+      friends: [16, 4, 8]
     }])
   })
+   
   it('should have an average step goal', function () {
-    let user1 = new UserRepository(userData)
-    user1.avgStepGoal()
-    expect(user1.averageStepGoal).to.equal(6700)
+    expect(repo.avgStepGoal()).to.equal(10000)
   })
 });


### PR DESCRIPTION
Fixed the UserRepository class test file so that all of the tests run and pass now that we no longer have a dataset file. Refactored the test to include a beforeEach at the top of the test which all around cleaned the code up.